### PR TITLE
Spotify Integration to showcase user Spotify activity

### DIFF
--- a/CRIP/Spotify-Proposal.md
+++ b/CRIP/Spotify-Proposal.md
@@ -1,6 +1,6 @@
 | proposal | title              | description                   | author                     | discussions-to | status | type        | category | created    | requires |
 |----------|--------------------|-------------------------------|----------------------------|----------------|--------|-------------|----------|------------|----------|
-| CRIP-1   | Spotify Integration | Integration with Spotify API to showcase user Spotify activity | John Doe <john.doe@example.com> |                | Draft  | Integration | CRIP     | 2024-06-11 |          |
+| CRIP-1   | Spotify Integration | Integration with Spotify API to showcase user Spotify activity | Om Saxena omsaxena.137@gmail.com |                | Draft  | Integration | CRIP     | 2024-06-11 |          |
 
 ## Title
 

--- a/CRIP/Spotify-Proposal.md
+++ b/CRIP/Spotify-Proposal.md
@@ -1,0 +1,60 @@
+| proposal | title              | description                   | author                     | discussions-to | status | type        | category | created    | requires |
+|----------|--------------------|-------------------------------|----------------------------|----------------|--------|-------------|----------|------------|----------|
+| CRIP-1   | Spotify Integration | Integration with Spotify API to showcase user Spotify activity | John Doe <john.doe@example.com> |                | Draft  | Integration | CRIP     | 2024-06-11 |          |
+
+## Title
+
+Spotify Integration
+
+## Introduction
+
+This proposal suggests integrating Spotify with the Catoff-Reclaim project. The integration aims to enhance user experience by allowing them to authenticate their Spotify activity, participate in music-related challenges, and share their music preferences within the Catoff platform. By connecting to Spotify's API, users can showcase their favorite tracks, playlists, and listening habits, fostering a vibrant music community on Catoff.
+
+## External APIs Needed
+
+- Spotify API: https://developer.spotify.com/documentation/web-api
+
+## Use Cases
+
+1. **User authentication**: Verify a user's Spotify account by accessing their listening history, playlists, and favorite artists.
+2. **Music analysis**: Analyze a user's listening habits, including top tracks, genres, and listening patterns over time.
+3. **Playlist synchronization**: Sync a user's Spotify playlists with Catoff, allowing them to participate in playlist challenges and share music recommendations.
+4. **Collaborative playlists**: Enable users to create and collaborate on playlists within the Catoff platform, leveraging Spotify's extensive music catalog.
+
+## Data Provider
+
+- **Name**: Spotify
+- **Hash Value**: [Is this hexadecimal value random, or does it need to be obtained from somewhere?]
+
+## Code Snippet
+
+Below is a code snippet that demonstrates the key parts of the Spotify integration. The full implementation should follow this service file template.
+
+**`services/SpotifyService.js`**
+
+```javascript
+const { ReclaimServiceResponse } = require('../utils/reclaimServiceResponse');
+const axios = require('axios');
+
+exports.processSpotifyData = async (proof, providerName) => {
+  const spotifyUserId = JSON.parse(proof[0].claimData.context).extractedParameters.userId;
+  const lastUpdateTimeStamp = proof[0].claimData.timestamp;
+
+  const userData = await getUserData(spotifyUserId);
+
+  return new ReclaimServiceResponse(providerName, lastUpdateTimeStamp, spotifyUserId, userData, proof[0]);
+};
+
+const getUserData = async (userId) => {
+  try {
+    const response = await axios.get(`https://api.spotify.com/v1/users/${userId}`);
+    const userData = response.data;
+
+    console.log(`User data for Spotify user ${userId}:`, userData);
+    return userData;
+  } catch (error) {
+    console.error(`Error fetching Spotify user data for ${userId}:`, error);
+    return null;
+  }
+};
+```


### PR DESCRIPTION
This proposal suggests integrating Spotify with the Catoff-Reclaim project. The integration aims to enhance user experience by allowing them to authenticate their Spotify activity, participate in music-related challenges, and share their music preferences within the Catoff platform. By connecting to Spotify's API, users can showcase their favorite tracks, playlists, and listening habits, fostering a vibrant music community on Catoff.