### PR TITLE
Added Lichess reclaim/catoff integration for user verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 TWITTER_ANALYTICS_VIEWS_SECRET=your-twitter-secret
 GITHUB_ACCOUNT_VERIFICATION_SECRET=your-github-secret
 RECLAIM_GITHUB_TOKEN=your-github-token
+LICHESS_API_KEY=your-lichess-api-key

--- a/CRIP/CRIP-7.md
+++ b/CRIP/CRIP-7.md
@@ -1,0 +1,71 @@
+| proposal | title               | description                                              | author       | discussions-to             | status | type        | category | created    | requires |
+|----------|---------------------|----------------------------------------------------------|--------------|----------------------------|--------|-------------|----------|------------|----------|
+| CRIP-7   | Lichess Integration | Integration with Lichess API to validate user statistics | Gaurav Shah  | <gauravkshah312@gmail.com> | Draft  | Integration | CRIP     | 2024-06-20 |          |
+
+## Title
+
+Lichess Integration
+
+## Introduction
+
+This proposal outlines the integration of Lichess as a data provider for the Catoff-Reclaim integration project. The integration aims to retrieve and process user activity and gameplay data of Lichess players, such as wins, draws, losses, username verification and multiple other metrics, to be used within the Catoff platform. This will enable users to validate their chess profiles and use them for various challenges and verifications related to e-sports challenges and chess based events on Catoff platform.
+
+## External APIs Needed
+
+- Lichess API: https://lichess.org/api
+
+## Use Cases
+
+1. **Player Verification**: Verify the activity of user on Lichess by checking their player profile and scores.
+2. **Challenge Participation**: Allow users to participate in challenges that require proof of past game activity.
+3. **Skill Assessment**: Assess players' chess skills based on their past competition activity.
+
+## Data Provider
+
+- **Name**: Lichess
+- **Hash Value**: [0xf02d001e7d9676cb422671420de325360988a49d8df75405c8c46b5969600994]
+
+## Code Snippet
+
+Below is a code snippet that demonstrates the key parts of the Lichess player profile integration. The full implementation should follow the service file template.
+
+**`services/pubgService.js`**
+
+```javascript
+const axios = require('axios')
+const { ReclaimServiceResponse } = require('../utils/reclaimServiceResponse')
+require('dotenv').config()
+
+exports.processLichessData = async (proof, providerName) => {
+  const lichessUsername = JSON.parse(proof[0].claimData.context)
+    .extractedParameters.username
+  const lastUpdateTimeStamp = proof[0].claimData.timestampS
+
+  console.log(`Lichess username: ${lichessUsername}`)
+  const userData = await getUserData(lichessUsername)
+
+  return new ReclaimServiceResponse(
+    providerName,
+    lastUpdateTimeStamp,
+    lichessUsername,
+    userData,
+    proof[0]
+  )
+}
+
+const getUserData = async username => {
+  const url = `https://lichess.org/api/user/${username}`
+
+  const data = await axios.get(url, {
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${process.env.LICHESS_API_KEY}`,
+    },
+  })
+  const response = data
+
+  console.log(`Current data of ${username} is given below:`)
+  console.dir(response.data, { depth: null })
+  return response.data
+}
+```

--- a/src/services/lichessService.js
+++ b/src/services/lichessService.js
@@ -1,0 +1,36 @@
+const axios = require('axios')
+const { ReclaimServiceResponse } = require('../utils/reclaimServiceResponse')
+require('dotenv').config()
+
+exports.processLichessData = async (proof, providerName) => {
+  const lichessUsername = JSON.parse(proof[0].claimData.context)
+    .extractedParameters.username
+  const lastUpdateTimeStamp = proof[0].claimData.timestampS
+
+  console.log(`Lichess username: ${lichessUsername}`)
+  const userData = await getUserData(lichessUsername)
+
+  return new ReclaimServiceResponse(
+    providerName,
+    lastUpdateTimeStamp,
+    lichessUsername,
+    userData,
+    proof[0]
+  )
+}
+
+const getUserData = async username => {
+  const url = `https://lichess.org/api/user/${username}`
+
+  const data = await axios.get(url, {
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${process.env.LICHESS_API_KEY}`,
+    },
+  })
+  const response = data
+
+  console.log(`Current data of ${username} is given below:`)
+  console.dir(response.data, { depth: null })
+  return response
+}

--- a/src/services/reclaimService.js
+++ b/src/services/reclaimService.js
@@ -1,13 +1,21 @@
 const axios = require('axios')
 const { Reclaim } = require('@reclaimprotocol/js-sdk')
-const { RECLAIM_PROVIDER_ID, RECLAIM_APP_ID } = require('../utils/constants')
+const {
+  RECLAIM_PROVIDER_ID,
+  RECLAIM_APP_ID,
+  RECLAIM_APP_SECRET,
+  RECLAIM_PROVIDER_NAME,
+} = require('../utils/constants')
 const { processTwitterData } = require('./twitterService')
 const { processGitHubData } = require('./githubService')
+const { processLichessData } = require('./lichessService')
 
-exports.signWithProviderID = async (userId, providerId) => {
-  const providerName = RECLAIM_PROVIDER_ID[providerId]
+exports.signWithProviderID = async (userId, tag) => {
+  const providerName = RECLAIM_PROVIDER_NAME[tag]
+  const providerId = RECLAIM_PROVIDER_ID[tag]
   const reclaimAppID = RECLAIM_APP_ID[providerName]
-  const reclaimAppSecret = process.env[`${providerName}_SECRET`]
+  const reclaimAppSecret = RECLAIM_APP_SECRET[`${providerName}_SECRET`]
+  console.log(providerName, providerId, reclaimAppID, reclaimAppSecret)
 
   console.log(
     `Sending signature request to Reclaim for userId: ${userId} with providerName: ${providerName}`
@@ -48,6 +56,10 @@ const handleReclaimSession = async (userId, reclaimClient, providerName) => {
             break
           case 'GITHUB_ACCOUNT_VERIFICATION':
             processedData = await processGitHubData(proof, providerName)
+            break
+          case 'LICHESS_VERIFICATION':
+            processedData = await processLichessData(proof, providerName)
+            console.log(processedData)
             break
           default:
             throw new Error(`No handler for provider: ${providerName}`)

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,9 +1,19 @@
-exports.RECLAIM_PROVIDER_ID = {
+exports.RECLAIM_PROVIDER_NAME = {
   twitter: 'TWITTER_ANALYTICS_VIEWS',
   github: 'GITHUB_ACCOUNT_VERIFICATION',
+  lichess: 'LICHESS_VERIFICATION',
 }
 
 exports.RECLAIM_APP_ID = {
   TWITTER_ANALYTICS_VIEWS: 'your-twitter-app-id',
   GITHUB_ACCOUNT_VERIFICATION: 'your-github-app-id',
+  LICHESS_VERIFICATION: 'your-lichess-app-id',
+}
+
+exports.RECLAIM_PROVIDER_ID = {
+  lichess: 'your-app-provider-id'
+}
+
+exports.RECLAIM_APP_SECRET = {
+  LICHESS_VERIFICATION_SECRET: '0xf02d001e7d9676cb422671420de325360988a49d8df75405c8c46b5969600994'
 }


### PR DESCRIPTION
This proposal outlines the integration of Lichess as a data provider for the Catoff-Reclaim integration project. The integration aims to retrieve and process user activity and gameplay data of Lichess players, such as wins, draws, losses, username verification and multiple other metrics, to be used within the Catoff platform. This will enable users to validate their chess profiles and use them for various challenges and verifications related to e-sports challenges and chess based events on Catoff platform.