### PR TITLE
Add Steam ID integration with Catoff

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 TWITTER_ANALYTICS_VIEWS_SECRET=your-twitter-secret
 GITHUB_ACCOUNT_VERIFICATION_SECRET=your-github-secret
 RECLAIM_GITHUB_TOKEN=your-github-token
+STEAM_ID_SECRET=your-steam-secret

--- a/CRIP/CRIP-2.md
+++ b/CRIP/CRIP-2.md
@@ -1,6 +1,6 @@
 | proposal | title              | description                                                | author                          | discussions-to | status | type        | category | created    | requires |
 | -------- | ------------------ | ---------------------------------------------------------- | ------------------------------- | -------------- | ------ | ----------- | -------- | ---------- | -------- |
-| CRIP-2   | Steam ID Integration | Integration with Steam to ret | John Doe <john.doe@example.com> |                | Draft  | Integration | CRIP     | 2024-06-01 |          |
+| CRIP-2   | Steam ID Integration | Integration with Steam to ret | Ankit Singh <akashthakur70423@gmail.com> |                | Draft  | Integration | CRIP     | 2024-07-04 |          |
 
 ## Title
 

--- a/CRIP/CRIP-2.md
+++ b/CRIP/CRIP-2.md
@@ -1,0 +1,54 @@
+| proposal | title              | description                                                | author                          | discussions-to | status | type        | category | created    | requires |
+| -------- | ------------------ | ---------------------------------------------------------- | ------------------------------- | -------------- | ------ | ----------- | -------- | ---------- | -------- |
+| CRIP-2   | Steam ID Integration | Integration with Steam to ret | John Doe <john.doe@example.com> |                | Draft  | Integration | CRIP     | 2024-06-01 |          |
+
+## Title
+
+Steam ID Integration
+
+## Introduction
+
+This proposal outlines the integration of Steam as a data provider for the Catoff-Reclaim integration project. The integration aims to retrieve Steam ID data from Steam, So we can know the player information through there Steam ID, to be used within the Catoff platform. This will enable users to validate their gaming activity and use it for various challenges and verifications on Catoff. Through this integration, users can leverage their Steam activity to participate in gamified experiences, earn rewards, and build their reputation on the Catoff platform.
+
+## External APIs Needed
+
+- No
+
+## Use Cases
+
+1. **User Verification**: Verify the activity of users on Steam by checking their Steam ID. This helps ensure that users are actively engaged in gaming and can authenticate their gaming history.
+2. **Challenge Participation**: Allow users to participate in challenges that require proof of Steam activity. Users can demonstrate their gaming skills and achievements to qualify for various gaming competitions and events on the Catoff platform.
+3. **Skill Assessment**: Assess users' gaming skills and expertise based on their Steam activity. This includes evaluating the number of hours played, achievements unlocked, and games completed, providing a comprehensive view of a user's gaming proficiency.
+
+## Data Provider
+
+- **Name**: Steam ID - Fix
+- **Hash Value**: 0x5f5312e27124dc7605f70a7d884e169049679b93f91c137b4d18a8569d825900
+
+## Code Snippet
+
+Below is a code snippet that demonstrates the key parts of the Steam ID integration. The full implementation should follow the service file template.
+
+**`services/githubService.js`**
+
+```javascript
+const axios = require('axios')
+const { ReclaimServiceResponse } = require('../utils/reclaimServiceResponse')
+
+exports.processSteamData = async (proof, providerName) => {
+  const steam_Id = JSON.parse(proof[0]?.claimData?.context).extractedParameters
+    ?.CLAIM_DATA // It will give me the Steam ID
+  let url = JSON.parse(proof[0]?.claimData?.parameters).url // URl of the Steam Account
+  const matchurl = url.match(/user\/([^\/]+)/)
+  const steam_Username = matchurl ? matchurl[1] : null //if the match url is null it menas there is no username, so that username will be NULL
+  const lastUpdateTimeStamp = JSON.parse(proof[0].claimData.timestampS)
+
+  return new ReclaimServiceResponse(
+    providerName,
+    lastUpdateTimeStamp,
+    steam_Username,
+    parseInt(steam_Id, 10),
+    proof[0]
+  )
+}
+```

--- a/src/services/reclaimService.js
+++ b/src/services/reclaimService.js
@@ -3,6 +3,8 @@ const { Reclaim } = require('@reclaimprotocol/js-sdk')
 const { RECLAIM_PROVIDER_ID, RECLAIM_APP_ID } = require('../utils/constants')
 const { processTwitterData } = require('./twitterService')
 const { processGitHubData } = require('./githubService')
+const { processSteamData } = require('./steamService')
+require('dotenv').config()
 
 exports.signWithProviderID = async (userId, providerId) => {
   const providerName = RECLAIM_PROVIDER_ID[providerId]
@@ -21,7 +23,7 @@ exports.signWithProviderID = async (userId, providerId) => {
     )
     const { requestUrl: signedUrl } =
       await reclaimClient.createVerificationRequest()
-
+    console.log(signedUrl, " SIGNED URL")
     await handleReclaimSession(userId, reclaimClient, providerName)
     return signedUrl
   } catch (error) {
@@ -48,6 +50,9 @@ const handleReclaimSession = async (userId, reclaimClient, providerName) => {
             break
           case 'GITHUB_ACCOUNT_VERIFICATION':
             processedData = await processGitHubData(proof, providerName)
+            break
+          case 'STEAM_ID':
+            processedData = await processSteamData(proof, providerName)
             break
           default:
             throw new Error(`No handler for provider: ${providerName}`)

--- a/src/services/reclaimService.js
+++ b/src/services/reclaimService.js
@@ -23,7 +23,6 @@ exports.signWithProviderID = async (userId, providerId) => {
     )
     const { requestUrl: signedUrl } =
       await reclaimClient.createVerificationRequest()
-    console.log(signedUrl, " SIGNED URL")
     await handleReclaimSession(userId, reclaimClient, providerName)
     return signedUrl
   } catch (error) {

--- a/src/services/steamService.js
+++ b/src/services/steamService.js
@@ -1,0 +1,18 @@
+const axios = require('axios')
+const { ReclaimServiceResponse } = require('../utils/reclaimServiceResponse')
+
+exports.processSteamData = async (proof, providerName) => {
+    const steam_Id = JSON.parse(proof[0]?.claimData?.context).extractedParameters?.CLAIM_DATA // It will give me the Steam ID
+    let url = JSON.parse(proof[0]?.claimData?.parameters).url // URl of the Steam Account
+    const matchurl = url.match(/user\/([^\/]+)/)
+    const steam_Username = matchurl ? matchurl[1] : null //if the match url is null it menas there is no username, so that username will be NULL
+    const lastUpdateTimeStamp = JSON.parse(proof[0].claimData.timestampS)
+    
+    return new ReclaimServiceResponse(
+        providerName,
+        lastUpdateTimeStamp,
+        steam_Username,
+        parseInt(steam_Id, 10),
+        proof[0]
+    )
+}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,11 +1,11 @@
 exports.RECLAIM_PROVIDER_ID = {
   twitter: 'TWITTER_ANALYTICS_VIEWS',
   github: 'GITHUB_ACCOUNT_VERIFICATION',
-  "1bba104c-f7e3-4b58-8b42-f8c0346cdeab": 'STEAM_ID',
+  STEAM_ID: 'STEAM_ID',
 }
 
 exports.RECLAIM_APP_ID = {
   TWITTER_ANALYTICS_VIEWS: 'your-twitter-app-id',
   GITHUB_ACCOUNT_VERIFICATION: 'your-github-app-id',
-  STEAM_ID: '0x58A7Ad9be91BB6E8E5a09bB031688388DC83a915',
+  STEAM_ID: 'your-steam-app-id',
 }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,9 +1,11 @@
 exports.RECLAIM_PROVIDER_ID = {
   twitter: 'TWITTER_ANALYTICS_VIEWS',
   github: 'GITHUB_ACCOUNT_VERIFICATION',
+  "1bba104c-f7e3-4b58-8b42-f8c0346cdeab": 'STEAM_ID',
 }
 
 exports.RECLAIM_APP_ID = {
   TWITTER_ANALYTICS_VIEWS: 'your-twitter-app-id',
   GITHUB_ACCOUNT_VERIFICATION: 'your-github-app-id',
+  STEAM_ID: '0x58A7Ad9be91BB6E8E5a09bB031688388DC83a915',
 }


### PR DESCRIPTION
This pull request integrates Steam ID as a data provider on the Reclaim protocol with Catoff. Users can now view Steam profiles directly on the Catoff platform with the help of their Steam ID.